### PR TITLE
Fix: slippage value

### DIFF
--- a/src/components/TransactionSettings/index.tsx
+++ b/src/components/TransactionSettings/index.tsx
@@ -105,10 +105,10 @@ export default function SlippageTabs({
   const [deadlineFocused, setDeadlineFocused] = useState(false)
 
   const slippageInputIsValid =
-    slippageInput === '' ||
-    (!Number.isNaN(Number(slippageInput)) &&
-      rawSlippage >= 10 &&
-      rawSlippage.toFixed(2) === Math.round(Number.parseFloat(slippageInput) * 100).toFixed(2))
+    !Number.isNaN(Number(slippageInput)) &&
+    // 10 is 0.1% slippage and less than 0.1 is not desirable
+    rawSlippage >= 10 &&
+    rawSlippage.toFixed(2) === Math.round(Number.parseFloat(slippageInput) * 100).toFixed(2)
 
   const deadlineInputIsValid = deadlineInput === '' || (deadline / 60).toString() === deadlineInput
 

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -90,10 +90,10 @@ export function useTradeExactInUniswapV2(
   const { chainId } = useActiveWeb3React()
   const allowedPairs = useAllCommonPairs(currencyAmountIn?.currency, currencyOut, platform)
   const multihop = useIsMultihop()
-  const userSlippageTolerance = useUserSlippageTolerance().toString()
+  const userSlippageTolerance = useUserSlippageTolerance()
 
   return useMemo(() => {
-    const maximumSlippage = new Percent(userSlippageTolerance, '10000')
+    const maximumSlippage = new Percent(userSlippageTolerance.toString(), '10000')
     if (currencyAmountIn && currencyOut && allowedPairs.length > 0 && chainId && platform.supportsChain(chainId)) {
       return (
         UniswapV2Trade.computeTradesExactIn({
@@ -123,10 +123,10 @@ export function useTradeExactOutUniswapV2(
   const { chainId } = useActiveWeb3React()
   const allowedPairs = useAllCommonPairs(currencyIn, currencyAmountOut?.currency, platform)
   const multihop = useIsMultihop()
-  const userSlippageTolerance = useUserSlippageTolerance().toString()
+  const userSlippageTolerance = useUserSlippageTolerance()
 
   return useMemo(() => {
-    const maximumSlippage = new Percent(userSlippageTolerance, '10000')
+    const maximumSlippage = new Percent(userSlippageTolerance.toString(), '10000')
     if (currencyIn && currencyAmountOut && allowedPairs.length > 0 && chainId && platform.supportsChain(chainId)) {
       return (
         UniswapV2Trade.computeTradesExactOut({

--- a/src/lib/eco-router/hooks.ts
+++ b/src/lib/eco-router/hooks.ts
@@ -31,7 +31,7 @@ export function useEcoRouterExactIn(currencyAmountIn?: CurrencyAmount, currencyO
   // Used to trigger computing trade route
   const currencyInAndOutAdddress = `${currencyOut?.address}-${currencyAmountIn?.currency.address}`
   // User max slippage
-  const userSlippageTolerance = useUserSlippageTolerance().toString()
+  const userSlippageTolerance = useUserSlippageTolerance()
 
   useEffect(() => {
     let isCancelled = false
@@ -55,7 +55,7 @@ export function useEcoRouterExactIn(currencyAmountIn?: CurrencyAmount, currencyO
       {
         currencyAmountIn,
         currencyOut,
-        maximumSlippage: new Percent(userSlippageTolerance, '10000'),
+        maximumSlippage: new Percent(userSlippageTolerance.toString(), '10000'),
         receiver: account ?? undefined,
       },
       {
@@ -117,7 +117,7 @@ export function useEcoRouterExactOut(currencyIn?: Currency, currencyAmountOut?: 
   // Used to trigger computing trade route
   const currencyInAndOutAdddress = `${currencyIn?.address}-${currencyAmountOut?.currency.address}`
   // User max slippage
-  const userSlippageTolerance = useUserSlippageTolerance().toString()
+  const userSlippageTolerance = useUserSlippageTolerance()
 
   useEffect(() => {
     let isCancelled = false
@@ -141,7 +141,7 @@ export function useEcoRouterExactOut(currencyIn?: Currency, currencyAmountOut?: 
       {
         currencyAmountOut,
         currencyIn,
-        maximumSlippage: new Percent(userSlippageTolerance, '10000'),
+        maximumSlippage: new Percent(userSlippageTolerance.toString(), '10000'),
         receiver: account ?? undefined,
       },
       {


### PR DESCRIPTION
# Summary
Fixes #1178 #1236 

So far regardless of the "slippage tolerance" choice in the UI, the "min received" window showed 3% slippage. The "amountOutMin" parameter sent with the transaction used this 3% slippage value as well.
This fix allows user to change slippage value and the "amountOutMin" parameter sent in the transaction should change proportionally as well.
Also make sure slippage value set by user is within the range 0.1-50%

  # To Test

1. Go to swapr app
2. Swap an asset X for an asset Y
3. For k as the price found, min received below will be 0.97k
4. Open Transactions Settings on the top right corner
5. Change slippage to any value
6. App is finding new best route and output amount includes new slippage value.
7. Open settings popup. Slippage value can be set only for range 0.1 - 50%. Otherwise invalid error message is shown.

![image](https://user-images.githubusercontent.com/88723742/178509932-cfe4ea8f-deae-4063-8d6a-3769b4fdfad9.png)

