### PR TITLE
fix:  limit price input type on limit order box

### DIFF
--- a/src/pages/Swap/LimitOrderBox/components/InputGroup/styled.ts
+++ b/src/pages/Swap/LimitOrderBox/components/InputGroup/styled.ts
@@ -46,4 +46,16 @@ export const StyledInput = styled.input`
   background: transparent;
   outline: none;
   border: none;
+
+  /* Chrome, Safari, Edge, Opera */
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  &[type='number'] {
+    -moz-appearance: textfield;
+  }
 `

--- a/src/pages/Swap/LimitOrderBox/components/OrderLimitPriceField/OrderLimitPriceField.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/OrderLimitPriceField/OrderLimitPriceField.tsx
@@ -161,6 +161,7 @@ export function OrderLimitPriceField({ id }: OrderLimitPriceFieldProps) {
       <InputGroup.InnerWrapper>
         <InputGroup.Input
           id={id}
+          type="number"
           onKeyDown={e => {
             if (invalidChars.includes(e.key)) {
               e.preventDefault()


### PR DESCRIPTION
# Summary

This input should only accept numbers. This fixes bug that shows `NAN% `.

<img width="431" alt="image" src="https://user-images.githubusercontent.com/5664434/210665364-b9a3db43-277c-469a-b491-75a9df7ac92c.png">

<img width="448" alt="image" src="https://user-images.githubusercontent.com/5664434/210665529-3d0a6912-86ef-48bc-b5d9-d6759b5448b0.png">


  # To Test

1. Go to limit orders
- [ ] add a string to limit price order
- [ ]  check if it let's you put the string

  # Background

*Optional: Give background information for changes you've made, that might be difficult to explain via comments*

