### PR TITLE
Updated Base Modal Styling and Currency Searching Modal Logic

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -39,7 +39,7 @@ const StyledDialogContent = styled(({ minHeight, maxHeight, maxWidth, mobile, is
     overflow-y: ${({ mobile }) => (mobile ? 'scroll' : 'hidden')};
     overflow-x: hidden;
 
-    align-self: ${({ mobile }) => (mobile ? 'flex-end' : 'center')};
+    align-self: ${({ mobile }) => (mobile ? 'flex-start' : 'center')};
 
     max-width: ${({ maxWidth }) => maxWidth}px;
     ${({ maxHeight }) =>
@@ -63,11 +63,11 @@ const StyledDialogContent = styled(({ minHeight, maxHeight, maxWidth, mobile, is
       ${
         mobile &&
         css`
-          width: 100vw;
+          width: 96vw;
           border-radius: 20px;
           border-bottom-left-radius: 0;
           border-bottom-right-radius: 0;
-          margin-bottom: 72px;
+          margin: 10px 0 72px;
         `
       }
     `}

--- a/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
+++ b/src/components/SearchModal/CurrencySearch/CurrencySearch.component.tsx
@@ -184,7 +184,7 @@ export const CurrencySearch = ({
             fontWeight={500}
           />
         </Row>
-        {showCommonBases && (
+        {showCommonBases && !searchQuery && (
           <CommonTokens chainId={chainId} onCurrencySelect={onCurrencySelect} selectedCurrency={selectedCurrency} />
         )}
       </AutoColumn>


### PR DESCRIPTION
# Summary

Resolves #1656.

There's an issue with Currency Searching modal in mobile view, while typing currencies are not visible because they are behind the keyboard. This pull request resolves that by updating base modal stylings in mobile view by moving the modal to the top of the screen. Updated is the logic as well in order to create more functional Currency Searching modal, when you start typing common currencies are removed from the modal.

🍀