### PR TITLE
feature: default limit price to 1%

### DIFF
--- a/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
@@ -77,7 +77,7 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
 
   const [inputFocus, setInputFocus] = useState<InputFocus>(InputFocus.SELL)
 
-  const [fetchMarketPrice, setFetchMarketPrice] = useState<boolean>(true)
+  const [fetchMarketPrice, setFetchMarketPrice] = useState<boolean>(false)
   const [marketPriceInterval, setMarketPriceInterval] = useState<NodeJS.Timer | undefined>()
 
   useLayoutEffect(() => {
@@ -98,72 +98,75 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
     setErrorMessage('')
   }
 
-  const setToMarket = useCallback(async () => {
-    const signer = provider.getSigner()
-    if (!limitOrder.buyToken || !limitOrder.sellToken) {
-      return
-    }
-
-    const order = JSON.parse(JSON.stringify(limitOrder))
-
-    const token = limitOrder.kind === LimitOrderKind.SELL ? sellTokenAmount : buyTokenAmount
-
-    const tokenAmount = Number(token.toExact()) > 1 ? token.toExact() : '1'
-
-    order.sellAmount = parseUnits(tokenAmount, token.currency.decimals).toString()
-
-    const cowQuote = await getQuote({
-      chainId,
-      signer,
-      order: { ...order, expiresAt: dayjs().add(GET_QUOTE_EXPIRY_MINUTES, OrderExpiresInUnit.Minutes).unix() },
-    })
-
-    if (cowQuote !== undefined) {
-      const {
-        quote: { buyAmount, sellAmount },
-      } = cowQuote
-
-      const nextLimitPriceFloat =
-        limitOrder.kind === LimitOrderKind.SELL
-          ? formatMarketPrice(buyAmount, buyTokenAmount.currency.decimals, tokenAmount) * SELL_LIMIT_PRICE_PERCENTAGE
-          : formatMarketPrice(sellAmount, sellTokenAmount.currency.decimals, tokenAmount) * BUY_LIMIT_PRICE_PERCENTAGE
-
-      const limitPrice = parseUnits(
-        nextLimitPriceFloat.toFixed(6),
-        limitOrder.kind === LimitOrderKind.SELL ? sellTokenAmount.currency.decimals : buyTokenAmount.currency.decimals
-      ).toString()
-
-      const { amount, buyAmountWei, sellAmountWei, newBuyTokenAmount, newSellTokenAmount } = computeNewAmount(
-        buyTokenAmount,
-        sellTokenAmount,
-        nextLimitPriceFloat,
-        limitOrder.kind,
-        inputFocus
-      )
-
-      setFormattedLimitPrice(toFixedSix(nextLimitPriceFloat))
-
-      if (inputFocus === InputFocus.SELL) {
-        setBuyTokenAmount(newBuyTokenAmount)
-        setFormattedBuyAmount(toFixedSix(amount))
-        setLimitOrder(oldLimitOrder => ({
-          ...oldLimitOrder,
-          kind: limitOrder.kind,
-          limitPrice: limitPrice,
-          buyAmount: buyAmountWei,
-        }))
-      } else {
-        setSellTokenAmount(newSellTokenAmount)
-        setFormattedSellAmount(toFixedSix(amount))
-        setLimitOrder(oldLimitOrder => ({
-          ...oldLimitOrder,
-          kind: limitOrder.kind,
-          limitPrice: limitPrice,
-          sellAmount: sellAmountWei,
-        }))
+  const setToMarket = useCallback(
+    async (sellPricePercentage = 1, buyPricePercentage = 1) => {
+      const signer = provider.getSigner()
+      if (!limitOrder.buyToken || !limitOrder.sellToken) {
+        return
       }
-    }
-  }, [buyTokenAmount, chainId, inputFocus, limitOrder, provider, sellTokenAmount])
+
+      const order = JSON.parse(JSON.stringify(limitOrder))
+
+      const token = limitOrder.kind === LimitOrderKind.SELL ? sellTokenAmount : buyTokenAmount
+
+      const tokenAmount = Number(token.toExact()) > 1 ? token.toExact() : '1'
+
+      order.sellAmount = parseUnits(tokenAmount, token.currency.decimals).toString()
+
+      const cowQuote = await getQuote({
+        chainId,
+        signer,
+        order: { ...order, expiresAt: dayjs().add(GET_QUOTE_EXPIRY_MINUTES, OrderExpiresInUnit.Minutes).unix() },
+      })
+
+      if (cowQuote !== undefined) {
+        const {
+          quote: { buyAmount, sellAmount },
+        } = cowQuote
+
+        const nextLimitPriceFloat =
+          limitOrder.kind === LimitOrderKind.SELL
+            ? formatMarketPrice(buyAmount, buyTokenAmount.currency.decimals, tokenAmount) * sellPricePercentage
+            : formatMarketPrice(sellAmount, sellTokenAmount.currency.decimals, tokenAmount) * buyPricePercentage
+
+        const limitPrice = parseUnits(
+          nextLimitPriceFloat.toFixed(6),
+          limitOrder.kind === LimitOrderKind.SELL ? sellTokenAmount.currency.decimals : buyTokenAmount.currency.decimals
+        ).toString()
+
+        const { amount, buyAmountWei, sellAmountWei, newBuyTokenAmount, newSellTokenAmount } = computeNewAmount(
+          buyTokenAmount,
+          sellTokenAmount,
+          nextLimitPriceFloat,
+          limitOrder.kind,
+          inputFocus
+        )
+
+        setFormattedLimitPrice(toFixedSix(nextLimitPriceFloat))
+
+        if (inputFocus === InputFocus.SELL) {
+          setBuyTokenAmount(newBuyTokenAmount)
+          setFormattedBuyAmount(toFixedSix(amount))
+          setLimitOrder(oldLimitOrder => ({
+            ...oldLimitOrder,
+            kind: limitOrder.kind,
+            limitPrice: limitPrice,
+            buyAmount: buyAmountWei,
+          }))
+        } else {
+          setSellTokenAmount(newSellTokenAmount)
+          setFormattedSellAmount(toFixedSix(amount))
+          setLimitOrder(oldLimitOrder => ({
+            ...oldLimitOrder,
+            kind: limitOrder.kind,
+            limitPrice: limitPrice,
+            sellAmount: sellAmountWei,
+          }))
+        }
+      }
+    },
+    [buyTokenAmount, chainId, inputFocus, limitOrder, provider, sellTokenAmount]
+  )
 
   const setToMarketRef = useRef(setToMarket)
 
@@ -171,17 +174,24 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
     setToMarketRef.current = setToMarket
   }, [setToMarket])
 
-  useEffect(() => {
-    const getMarketPrice = () => {
-      setToMarketRef.current().catch(e => {
-        console.error(e)
-        setIsPossibleToOrder({
-          status: true,
-          value: 0,
-        })
+  const getMarketPrice = (sellPricePercentage?: number, buyPricePercentage?: number) => {
+    setToMarketRef.current(sellPricePercentage, buyPricePercentage).catch(e => {
+      console.error(e)
+      setIsPossibleToOrder({
+        status: true,
+        value: 0,
       })
-    }
+    })
+  }
 
+  useEffect(() => {
+    if (!fetchMarketPrice) {
+      getMarketPrice(SELL_LIMIT_PRICE_PERCENTAGE, BUY_LIMIT_PRICE_PERCENTAGE)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chainId, account, buyTokenAmount.currency, sellTokenAmount.currency])
+
+  useEffect(() => {
     let refetchMarketPrice: NodeJS.Timeout | undefined
     if (fetchMarketPrice) {
       getMarketPrice()

--- a/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
@@ -21,7 +21,7 @@ import { useCurrencyBalances } from '../../../../../state/wallet/hooks'
 import { maxAmountSpend } from '../../../../../utils/maxAmountSpend'
 import AppBody from '../../../../AppBody'
 import { createCoWLimitOrder, getQuote, getVaultRelayerAddress } from '../../api/cow'
-import { GET_QUOTE_EXPIRY_MINUTES } from '../../constants'
+import { BUY_LIMIT_PRICE_PERCENTAGE, GET_QUOTE_EXPIRY_MINUTES, SELL_LIMIT_PRICE_PERCENTAGE } from '../../constants'
 import { LimitOrderFormContext } from '../../contexts/LimitOrderFormContext'
 import { InputFocus, LimitOrderKind, MarketPrices, OrderExpiresInUnit, SerializableLimitOrder } from '../../interfaces'
 import { computeNewAmount, getInitialState } from '../../utils'
@@ -125,8 +125,8 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
 
       const nextLimitPriceFloat =
         limitOrder.kind === LimitOrderKind.SELL
-          ? formatMarketPrice(buyAmount, buyTokenAmount.currency.decimals, tokenAmount)
-          : formatMarketPrice(sellAmount, sellTokenAmount.currency.decimals, tokenAmount)
+          ? formatMarketPrice(buyAmount, buyTokenAmount.currency.decimals, tokenAmount) * SELL_LIMIT_PRICE_PERCENTAGE
+          : formatMarketPrice(sellAmount, sellTokenAmount.currency.decimals, tokenAmount) * BUY_LIMIT_PRICE_PERCENTAGE
 
       const limitPrice = parseUnits(
         nextLimitPriceFloat.toFixed(6),

--- a/src/pages/Swap/LimitOrderBox/constants/index.ts
+++ b/src/pages/Swap/LimitOrderBox/constants/index.ts
@@ -8,3 +8,7 @@ export const supportedChainIdList = [ChainId.MAINNET, ChainId.GNOSIS]
 export const invalidChars = ['-', '+', 'e']
 
 export const GET_QUOTE_EXPIRY_MINUTES = 20
+
+export const SELL_LIMIT_PRICE_PERCENTAGE = 1.01
+
+export const BUY_LIMIT_PRICE_PERCENTAGE = 0.99


### PR DESCRIPTION
# Summary

Fixes #1673

Default limit price to 1%

  # To Test

1. Open limit orders
- [ ] Limit price should be 1% above buy price or 1% bellow sell price

