### PR TITLE
feat: add fathom analytics to ecobridge

### DIFF
--- a/bin/fathom-generate-events/eco-bridge-platforms.ts
+++ b/bin/fathom-generate-events/eco-bridge-platforms.ts
@@ -1,0 +1,65 @@
+import { ChainId } from '@swapr/sdk'
+
+interface EcoBridgePlatformInformation {
+  platformName: string
+  supportedChains: {
+    to: ChainId
+    from: ChainId
+  }[]
+}
+
+export const bridgeSupportedChains = (supportedChains: ChainId[]) =>
+  supportedChains
+    .flatMap((v, i) => supportedChains.slice(i + 1).map(w => [v, w]))
+    .map<any>(([from, to]) => ({
+      from,
+      to,
+    }))
+
+export function ecoBridgePlatformList(): EcoBridgePlatformInformation[] {
+  return [
+    {
+      platformName: 'arbitrum-testnet',
+      supportedChains: [{ from: ChainId.RINKEBY, to: ChainId.ARBITRUM_RINKEBY }],
+    },
+    {
+      platformName: 'arbitrum-mainnet',
+      supportedChains: [{ from: ChainId.MAINNET, to: ChainId.ARBITRUM_ONE }],
+    },
+    {
+      platformName: 'socket',
+      supportedChains: bridgeSupportedChains([
+        ChainId.ARBITRUM_ONE,
+        ChainId.MAINNET,
+        ChainId.POLYGON,
+        ChainId.GNOSIS,
+        ChainId.OPTIMISM_MAINNET,
+        ChainId.BSC_MAINNET,
+      ]),
+    },
+    {
+      platformName: 'xdai',
+      supportedChains: [{ from: ChainId.MAINNET, to: ChainId.XDAI }],
+    },
+    {
+      platformName: 'connext',
+      supportedChains: bridgeSupportedChains([
+        ChainId.ARBITRUM_ONE,
+        ChainId.MAINNET,
+        ChainId.POLYGON,
+        ChainId.GNOSIS,
+        ChainId.OPTIMISM_MAINNET,
+        ChainId.BSC_MAINNET,
+      ]),
+    },
+    {
+      platformName: 'omnibridge-eth-xdai',
+      supportedChains: [
+        {
+          from: ChainId.GNOSIS,
+          to: ChainId.MAINNET,
+        },
+      ],
+    },
+  ]
+}

--- a/bin/fathom-generate-events/file-content-generator.ts
+++ b/bin/fathom-generate-events/file-content-generator.ts
@@ -62,6 +62,20 @@ export function getNetworkNameByChainId(chainId: number): string {
 export function getEcoRouterVolumeUSDEventName(networkName: string, networkId: number, platformName: string): string {
     return \`\${networkName.toLowerCase()}-\${networkId}/ecoRouter/\${platformName.toLowerCase()}/volumeUSD\`;
 }
+
+/**
+ * Constructs EcoBridge volumeUSD event name for a given platform, from network and to network
+ */
+export function getEcoBridgeVolumeUSDEventName(
+  platformName: string,
+  fromNetworkId: number,
+  toNetworkId: number
+): string {
+  const fromNetworkName = getNetworkNameByChainId(fromNetworkId)
+  const toNetworkName = getNetworkNameByChainId(toNetworkId)
+  platformName = platformName.replace(/:/g, '-').toLowerCase()
+  return \`\${fromNetworkName}-\${fromNetworkId}/ecoBridge/\${platformName}/\${toNetworkName}-\${toNetworkId}/volumeUSD\`;
+}
 `
 
   return generatedFileContent

--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "esModuleInterop": true
-  }
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true
+  },
+  "include": ["../src"]
 }

--- a/src/analytics/generated/dev/fathom-events.json
+++ b/src/analytics/generated/dev/fathom-events.json
@@ -429,18 +429,494 @@
       "created_at": "2023-01-05 14:43:58"
     },
     {
-      "id": "JGFS8R74",
-      "object": "event",
-      "name": "bsc-56/ecoRouter/sushiswap/volumeUSD",
-      "currency": "dollar",
-      "created_at": "2023-01-05 14:44:49"
-    },
-    {
       "id": "AWWCLPCG",
       "object": "event",
       "name": "bsc-56/ecoRouter/pancakeswap/volumeUSD",
-      "currency": "dollar",
+      "currency": null,
       "created_at": "2023-01-05 14:44:49"
+    },
+    {
+      "id": "JGFS8R74",
+      "object": "event",
+      "name": "bsc-56/ecoRouter/sushiswap/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-05 14:44:49"
+    },
+    {
+      "id": "EIZQGTFD",
+      "object": "event",
+      "name": "arbitrum-rinkeby-421611/ecoBridge/arbitrum-testnet/rinkeby-4/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:14"
+    },
+    {
+      "id": "EVYZ2EIU",
+      "object": "event",
+      "name": "rinkeby-4/ecoBridge/arbitrum-testnet/arbitrum-rinkeby-421611/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:14"
+    },
+    {
+      "id": "AUI0GZYH",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/arbitrum-mainnet/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:15"
+    },
+    {
+      "id": "UHBHINCN",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/arbitrum-mainnet/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:15"
+    },
+    {
+      "id": "BC2IKEWJ",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:16"
+    },
+    {
+      "id": "D2VPT99D",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:16"
+    },
+    {
+      "id": "CDYATVTQ",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:17"
+    },
+    {
+      "id": "SAPTCMZ1",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:17"
+    },
+    {
+      "id": "7JV1XJVJ",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:18"
+    },
+    {
+      "id": "OCUIUXCM",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:18"
+    },
+    {
+      "id": "ZRNHZH6M",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:18"
+    },
+    {
+      "id": "5QY2H5PX",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:19"
+    },
+    {
+      "id": "OBYBBRNR",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:19"
+    },
+    {
+      "id": "PAFCKP10",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:19"
+    },
+    {
+      "id": "X4YJGSIQ",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:19"
+    },
+    {
+      "id": "S0F4FGKA",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:20"
+    },
+    {
+      "id": "UBDHQGIC",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:20"
+    },
+    {
+      "id": "UHG0IDXM",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:20"
+    },
+    {
+      "id": "P2CGJIGQ",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:21"
+    },
+    {
+      "id": "X1MG21WW",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:21"
+    },
+    {
+      "id": "42RR8BSH",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:22"
+    },
+    {
+      "id": "5NZBH2SH",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:22"
+    },
+    {
+      "id": "SNO3RZES",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:22"
+    },
+    {
+      "id": "TMEDPQA9",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:22"
+    },
+    {
+      "id": "V0G4MBBC",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:22"
+    },
+    {
+      "id": "8K0SMB3A",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:23"
+    },
+    {
+      "id": "CGZHTQNI",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:23"
+    },
+    {
+      "id": "QJTYB9RJ",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:23"
+    },
+    {
+      "id": "ZZGTY3UV",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:23"
+    },
+    {
+      "id": "BAFSLT8E",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:24"
+    },
+    {
+      "id": "KD6LURFV",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:24"
+    },
+    {
+      "id": "KOHGHIHI",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:24"
+    },
+    {
+      "id": "THJG74J1",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:24"
+    },
+    {
+      "id": "WMH1LIMU",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:24"
+    },
+    {
+      "id": "3XOMVTNM",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/xdai/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:25"
+    },
+    {
+      "id": "D6EFTKTX",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/xdai/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:25"
+    },
+    {
+      "id": "HJQ4SIVZ",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:26"
+    },
+    {
+      "id": "5JK12YRI",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:27"
+    },
+    {
+      "id": "CEQWOOZS",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:27"
+    },
+    {
+      "id": "LDU94RP0",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:27"
+    },
+    {
+      "id": "RCTOCBGE",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:27"
+    },
+    {
+      "id": "YJHIDEDW",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:27"
+    },
+    {
+      "id": "ACDBPNUI",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:28"
+    },
+    {
+      "id": "AS9O9BRL",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:28"
+    },
+    {
+      "id": "I42SVD0R",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:28"
+    },
+    {
+      "id": "PXTUUICC",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:28"
+    },
+    {
+      "id": "VJTBNZ4U",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:28"
+    },
+    {
+      "id": "A02FIFSP",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:29"
+    },
+    {
+      "id": "HKDVBITD",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:29"
+    },
+    {
+      "id": "PCRC1AC7",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:29"
+    },
+    {
+      "id": "PHIWMOWU",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:29"
+    },
+    {
+      "id": "XUJ1DPWS",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:29"
+    },
+    {
+      "id": "DP6CLAXO",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:30"
+    },
+    {
+      "id": "GR70ZORQ",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:30"
+    },
+    {
+      "id": "LQOGPTKI",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:30"
+    },
+    {
+      "id": "WWREDQAC",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:30"
+    },
+    {
+      "id": "YMKZPCSF",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:30"
+    },
+    {
+      "id": "HP7RLOQG",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:31"
+    },
+    {
+      "id": "J3Q8KOJY",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:31"
+    },
+    {
+      "id": "N0FUOWRB",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:31"
+    },
+    {
+      "id": "QLB4AAI0",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:31"
+    },
+    {
+      "id": "RIQGRRF4",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:31"
+    },
+    {
+      "id": "CIZQUQOZ",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/omnibridge-eth-xdai/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:32"
+    },
+    {
+      "id": "EOCKVRP0",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:32"
+    },
+    {
+      "id": "MIQBJZFL",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:32"
+    },
+    {
+      "id": "N1QQCQOB",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:32"
+    },
+    {
+      "id": "WLC9CTAC",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:32"
+    },
+    {
+      "id": "81WIALW3",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/omnibridge-eth-xdai/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:01:33"
     }
   ]
 }

--- a/src/analytics/generated/dev/index.ts
+++ b/src/analytics/generated/dev/index.ts
@@ -63,8 +63,76 @@ export type FathomRegisteredEventName =
   | 'optimism-10/ecoRouter/velodrome/volumeUSD'
   | 'undefined-56/ecoRouter/pancakeswap/volumeUSD'
   | 'undefined-56/ecoRouter/sushiswap/volumeUSD'
-  | 'bsc-56/ecoRouter/sushiswap/volumeUSD'
   | 'bsc-56/ecoRouter/pancakeswap/volumeUSD'
+  | 'bsc-56/ecoRouter/sushiswap/volumeUSD'
+  | 'arbitrum-rinkeby-421611/ecoBridge/arbitrum-testnet/rinkeby-4/volumeUSD'
+  | 'rinkeby-4/ecoBridge/arbitrum-testnet/arbitrum-rinkeby-421611/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/arbitrum-mainnet/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/arbitrum-mainnet/arbitrum-42161/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'gnosis-100/ecoBridge/xdai/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/xdai/gnosis-100/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'gnosis-100/ecoBridge/omnibridge-eth-xdai/ethereum-1/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/omnibridge-eth-xdai/gnosis-100/volumeUSD'
 export type FathomRegisteredNetworkName =
   | 'ethereum'
   | 'rinkeby'
@@ -525,21 +593,497 @@ export const siteEvents: FathomSiteInformation = {
       created_at: '2023-01-05 14:43:58',
     },
     {
-      id: 'JGFS8R74',
-      object: 'event',
-      name: 'bsc-56/ecoRouter/sushiswap/volumeUSD',
-      currency: 'dollar',
-      created_at: '2023-01-05 14:44:49',
-    },
-    {
       id: 'AWWCLPCG',
       object: 'event',
       name: 'bsc-56/ecoRouter/pancakeswap/volumeUSD',
-      currency: 'dollar',
+      currency: null,
       created_at: '2023-01-05 14:44:49',
     },
+    {
+      id: 'JGFS8R74',
+      object: 'event',
+      name: 'bsc-56/ecoRouter/sushiswap/volumeUSD',
+      currency: null,
+      created_at: '2023-01-05 14:44:49',
+    },
+    {
+      id: 'EIZQGTFD',
+      object: 'event',
+      name: 'arbitrum-rinkeby-421611/ecoBridge/arbitrum-testnet/rinkeby-4/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:14',
+    },
+    {
+      id: 'EVYZ2EIU',
+      object: 'event',
+      name: 'rinkeby-4/ecoBridge/arbitrum-testnet/arbitrum-rinkeby-421611/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:14',
+    },
+    {
+      id: 'AUI0GZYH',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/arbitrum-mainnet/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:15',
+    },
+    {
+      id: 'UHBHINCN',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/arbitrum-mainnet/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:15',
+    },
+    {
+      id: 'BC2IKEWJ',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:16',
+    },
+    {
+      id: 'D2VPT99D',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:16',
+    },
+    {
+      id: 'CDYATVTQ',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:17',
+    },
+    {
+      id: 'SAPTCMZ1',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:17',
+    },
+    {
+      id: '7JV1XJVJ',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:18',
+    },
+    {
+      id: 'OCUIUXCM',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:18',
+    },
+    {
+      id: 'ZRNHZH6M',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:18',
+    },
+    {
+      id: '5QY2H5PX',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:19',
+    },
+    {
+      id: 'OBYBBRNR',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:19',
+    },
+    {
+      id: 'PAFCKP10',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:19',
+    },
+    {
+      id: 'X4YJGSIQ',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:19',
+    },
+    {
+      id: 'S0F4FGKA',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:20',
+    },
+    {
+      id: 'UBDHQGIC',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:20',
+    },
+    {
+      id: 'UHG0IDXM',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:20',
+    },
+    {
+      id: 'P2CGJIGQ',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:21',
+    },
+    {
+      id: 'X1MG21WW',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:21',
+    },
+    {
+      id: '42RR8BSH',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:22',
+    },
+    {
+      id: '5NZBH2SH',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:22',
+    },
+    {
+      id: 'SNO3RZES',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:22',
+    },
+    {
+      id: 'TMEDPQA9',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:22',
+    },
+    {
+      id: 'V0G4MBBC',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:22',
+    },
+    {
+      id: '8K0SMB3A',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:23',
+    },
+    {
+      id: 'CGZHTQNI',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:23',
+    },
+    {
+      id: 'QJTYB9RJ',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:23',
+    },
+    {
+      id: 'ZZGTY3UV',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:23',
+    },
+    {
+      id: 'BAFSLT8E',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:24',
+    },
+    {
+      id: 'KD6LURFV',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:24',
+    },
+    {
+      id: 'KOHGHIHI',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:24',
+    },
+    {
+      id: 'THJG74J1',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:24',
+    },
+    {
+      id: 'WMH1LIMU',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:24',
+    },
+    {
+      id: '3XOMVTNM',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/xdai/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:25',
+    },
+    {
+      id: 'D6EFTKTX',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/xdai/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:25',
+    },
+    {
+      id: 'HJQ4SIVZ',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:26',
+    },
+    {
+      id: '5JK12YRI',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:27',
+    },
+    {
+      id: 'CEQWOOZS',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:27',
+    },
+    {
+      id: 'LDU94RP0',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:27',
+    },
+    {
+      id: 'RCTOCBGE',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:27',
+    },
+    {
+      id: 'YJHIDEDW',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:27',
+    },
+    {
+      id: 'ACDBPNUI',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:28',
+    },
+    {
+      id: 'AS9O9BRL',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:28',
+    },
+    {
+      id: 'I42SVD0R',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:28',
+    },
+    {
+      id: 'PXTUUICC',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:28',
+    },
+    {
+      id: 'VJTBNZ4U',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:28',
+    },
+    {
+      id: 'A02FIFSP',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:29',
+    },
+    {
+      id: 'HKDVBITD',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:29',
+    },
+    {
+      id: 'PCRC1AC7',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:29',
+    },
+    {
+      id: 'PHIWMOWU',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:29',
+    },
+    {
+      id: 'XUJ1DPWS',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:29',
+    },
+    {
+      id: 'DP6CLAXO',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:30',
+    },
+    {
+      id: 'GR70ZORQ',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:30',
+    },
+    {
+      id: 'LQOGPTKI',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:30',
+    },
+    {
+      id: 'WWREDQAC',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:30',
+    },
+    {
+      id: 'YMKZPCSF',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:30',
+    },
+    {
+      id: 'HP7RLOQG',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:31',
+    },
+    {
+      id: 'J3Q8KOJY',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:31',
+    },
+    {
+      id: 'N0FUOWRB',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:31',
+    },
+    {
+      id: 'QLB4AAI0',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:31',
+    },
+    {
+      id: 'RIQGRRF4',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:31',
+    },
+    {
+      id: 'CIZQUQOZ',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/omnibridge-eth-xdai/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:32',
+    },
+    {
+      id: 'EOCKVRP0',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:32',
+    },
+    {
+      id: 'MIQBJZFL',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:32',
+    },
+    {
+      id: 'N1QQCQOB',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:32',
+    },
+    {
+      id: 'WLC9CTAC',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:32',
+    },
+    {
+      id: '81WIALW3',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/omnibridge-eth-xdai/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:01:33',
+    },
   ],
-  timestamp: '2023-01-05T14:44:49.929Z',
+  timestamp: '2023-01-12T12:09:47.671Z',
 }
 
 /**
@@ -577,4 +1121,18 @@ export function getNetworkNameByChainId(chainId: number): string {
  */
 export function getEcoRouterVolumeUSDEventName(networkName: string, networkId: number, platformName: string): string {
   return `${networkName.toLowerCase()}-${networkId}/ecoRouter/${platformName.toLowerCase()}/volumeUSD`
+}
+
+/**
+ * Constructs EcoBridge volumeUSD event name for a given platform, from network and to network
+ */
+export function getEcoBridgeVolumeUSDEventName(
+  platformName: string,
+  fromNetworkId: number,
+  toNetworkId: number
+): string {
+  const fromNetworkName = getNetworkNameByChainId(fromNetworkId)
+  const toNetworkName = getNetworkNameByChainId(toNetworkId)
+  platformName = platformName.replace(/:/g, '-').toLowerCase()
+  return `${fromNetworkName}-${fromNetworkId}/ecoBridge/${platformName}/${toNetworkName}-${toNetworkId}/volumeUSD`
 }

--- a/src/analytics/generated/prod/fathom-events.json
+++ b/src/analytics/generated/prod/fathom-events.json
@@ -201,22 +201,498 @@
       "id": "R0M0D8UN",
       "object": "event",
       "name": "optimism-10/ecoRouter/velodrome/volumeUSD",
-      "currency": "dollar",
+      "currency": null,
       "created_at": "2023-01-05 14:50:44"
     },
     {
       "id": "QQKSHIK7",
       "object": "event",
       "name": "bsc-56/ecoRouter/sushiswap/volumeUSD",
-      "currency": "dollar",
+      "currency": null,
       "created_at": "2023-01-05 14:50:45"
     },
     {
       "id": "K3LNQ6P1",
       "object": "event",
       "name": "bsc-56/ecoRouter/pancakeswap/volumeUSD",
-      "currency": "dollar",
+      "currency": null,
       "created_at": "2023-01-05 14:50:46"
+    },
+    {
+      "id": "G4KOBM8P",
+      "object": "event",
+      "name": "rinkeby-4/ecoBridge/arbitrum-testnet/arbitrum-rinkeby-421611/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:05"
+    },
+    {
+      "id": "OX6AH4EV",
+      "object": "event",
+      "name": "arbitrum-rinkeby-421611/ecoBridge/arbitrum-testnet/rinkeby-4/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:05"
+    },
+    {
+      "id": "9ZMYBSMP",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/arbitrum-mainnet/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:06"
+    },
+    {
+      "id": "IR0D5BUY",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:06"
+    },
+    {
+      "id": "XMXILQVD",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/arbitrum-mainnet/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:06"
+    },
+    {
+      "id": "YDVH2XQG",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:06"
+    },
+    {
+      "id": "7CTL9KHX",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:07"
+    },
+    {
+      "id": "R5KGDSJI",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:07"
+    },
+    {
+      "id": "4KNR6ELM",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:08"
+    },
+    {
+      "id": "J4OBEPTE",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:08"
+    },
+    {
+      "id": "U8B0F4CT",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:08"
+    },
+    {
+      "id": "VZUNNBGV",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:08"
+    },
+    {
+      "id": "YSKIWPLS",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:08"
+    },
+    {
+      "id": "0XWO4N4I",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:09"
+    },
+    {
+      "id": "DZPGG0I8",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:09"
+    },
+    {
+      "id": "H50FXZ73",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:09"
+    },
+    {
+      "id": "N1OF1UZ8",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:09"
+    },
+    {
+      "id": "WYSUWDSJ",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:09"
+    },
+    {
+      "id": "5SLYILO3",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:10"
+    },
+    {
+      "id": "DHLPOXCT",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:10"
+    },
+    {
+      "id": "EHYGYJK3",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:10"
+    },
+    {
+      "id": "HU66ANFW",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:10"
+    },
+    {
+      "id": "JTXPZAMH",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:10"
+    },
+    {
+      "id": "QUNYNQKF",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:10"
+    },
+    {
+      "id": "BTFWR2F9",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:11"
+    },
+    {
+      "id": "CVT29IE3",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:11"
+    },
+    {
+      "id": "QS2I9DDE",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:11"
+    },
+    {
+      "id": "TYLPSBTO",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:11"
+    },
+    {
+      "id": "5SABZ3YC",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:12"
+    },
+    {
+      "id": "C5MTQUOF",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:12"
+    },
+    {
+      "id": "CSG7MXZE",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/socket/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:12"
+    },
+    {
+      "id": "CXBYHXWO",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:12"
+    },
+    {
+      "id": "VNGTVWUX",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/socket/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:12"
+    },
+    {
+      "id": "6ZFDGA8Z",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/socket/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:13"
+    },
+    {
+      "id": "OF3PEV9G",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/xdai/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:13"
+    },
+    {
+      "id": "TBQR17TC",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:13"
+    },
+    {
+      "id": "WBODOFAK",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:13"
+    },
+    {
+      "id": "XMCEG2CF",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/xdai/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:13"
+    },
+    {
+      "id": "8DDVCELX",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:14"
+    },
+    {
+      "id": "SLYRXJZK",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:14"
+    },
+    {
+      "id": "USYVDOV2",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:14"
+    },
+    {
+      "id": "UVVP5PGY",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:14"
+    },
+    {
+      "id": "KZDWAOUW",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:15"
+    },
+    {
+      "id": "9820I5UX",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:16"
+    },
+    {
+      "id": "LB4CN0TN",
+      "object": "event",
+      "name": "arbitrum-42161/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:16"
+    },
+    {
+      "id": "OGBTQGIZ",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:16"
+    },
+    {
+      "id": "UUFNKTOU",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/arbitrum-42161/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:16"
+    },
+    {
+      "id": "3UFBEOQ7",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:17"
+    },
+    {
+      "id": "H3YPX7X8",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:17"
+    },
+    {
+      "id": "NEELN1FL",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:17"
+    },
+    {
+      "id": "PIHTIOXI",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:17"
+    },
+    {
+      "id": "UDK1B6GZ",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:17"
+    },
+    {
+      "id": "1RC6EZNH",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:19"
+    },
+    {
+      "id": "8SR80H3E",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:19"
+    },
+    {
+      "id": "U0AIKPQ8",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:19"
+    },
+    {
+      "id": "XC1A7DAL",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:19"
+    },
+    {
+      "id": "DFBJIADF",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:20"
+    },
+    {
+      "id": "GCT9ZTPJ",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:20"
+    },
+    {
+      "id": "JYHTF4P7",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:20"
+    },
+    {
+      "id": "MZYBFAXY",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/polygon-137/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:20"
+    },
+    {
+      "id": "PNBTOJWZ",
+      "object": "event",
+      "name": "polygon-137/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:20"
+    },
+    {
+      "id": "6DWAXMIS",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/optimism-10/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:21"
+    },
+    {
+      "id": "MUH5FTS4",
+      "object": "event",
+      "name": "bsc-56/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:21"
+    },
+    {
+      "id": "PVY6UOF7",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:21"
+    },
+    {
+      "id": "U9UZ4EQH",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/connext/bsc-56/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:21"
+    },
+    {
+      "id": "YGLUCRGP",
+      "object": "event",
+      "name": "optimism-10/ecoBridge/connext/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:21"
+    },
+    {
+      "id": "2GDIENPO",
+      "object": "event",
+      "name": "ethereum-1/ecoBridge/omnibridge-eth-xdai/gnosis-100/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:22"
+    },
+    {
+      "id": "R5JAXFNA",
+      "object": "event",
+      "name": "gnosis-100/ecoBridge/omnibridge-eth-xdai/ethereum-1/volumeUSD",
+      "currency": null,
+      "created_at": "2023-01-12 10:07:22"
     }
   ]
 }

--- a/src/analytics/generated/prod/index.ts
+++ b/src/analytics/generated/prod/index.ts
@@ -33,6 +33,74 @@ export type FathomRegisteredEventName =
   | 'optimism-10/ecoRouter/velodrome/volumeUSD'
   | 'bsc-56/ecoRouter/sushiswap/volumeUSD'
   | 'bsc-56/ecoRouter/pancakeswap/volumeUSD'
+  | 'rinkeby-4/ecoBridge/arbitrum-testnet/arbitrum-rinkeby-421611/volumeUSD'
+  | 'arbitrum-rinkeby-421611/ecoBridge/arbitrum-testnet/rinkeby-4/volumeUSD'
+  | 'ethereum-1/ecoBridge/arbitrum-mainnet/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/arbitrum-mainnet/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/arbitrum-42161/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/ethereum-1/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/polygon-137/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'polygon-137/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'optimism-10/ecoBridge/socket/gnosis-100/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'gnosis-100/ecoBridge/socket/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/socket/optimism-10/volumeUSD'
+  | 'gnosis-100/ecoBridge/xdai/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/xdai/gnosis-100/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'arbitrum-42161/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/arbitrum-42161/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/ethereum-1/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/polygon-137/volumeUSD'
+  | 'polygon-137/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/optimism-10/volumeUSD'
+  | 'bsc-56/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'gnosis-100/ecoBridge/connext/bsc-56/volumeUSD'
+  | 'optimism-10/ecoBridge/connext/gnosis-100/volumeUSD'
+  | 'ethereum-1/ecoBridge/omnibridge-eth-xdai/gnosis-100/volumeUSD'
+  | 'gnosis-100/ecoBridge/omnibridge-eth-xdai/ethereum-1/volumeUSD'
 export type FathomRegisteredNetworkName =
   | 'ethereum'
   | 'rinkeby'
@@ -265,25 +333,501 @@ export const siteEvents: FathomSiteInformation = {
       id: 'R0M0D8UN',
       object: 'event',
       name: 'optimism-10/ecoRouter/velodrome/volumeUSD',
-      currency: 'dollar',
+      currency: null,
       created_at: '2023-01-05 14:50:44',
     },
     {
       id: 'QQKSHIK7',
       object: 'event',
       name: 'bsc-56/ecoRouter/sushiswap/volumeUSD',
-      currency: 'dollar',
+      currency: null,
       created_at: '2023-01-05 14:50:45',
     },
     {
       id: 'K3LNQ6P1',
       object: 'event',
       name: 'bsc-56/ecoRouter/pancakeswap/volumeUSD',
-      currency: 'dollar',
+      currency: null,
       created_at: '2023-01-05 14:50:46',
     },
+    {
+      id: 'G4KOBM8P',
+      object: 'event',
+      name: 'rinkeby-4/ecoBridge/arbitrum-testnet/arbitrum-rinkeby-421611/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:05',
+    },
+    {
+      id: 'OX6AH4EV',
+      object: 'event',
+      name: 'arbitrum-rinkeby-421611/ecoBridge/arbitrum-testnet/rinkeby-4/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:05',
+    },
+    {
+      id: '9ZMYBSMP',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/arbitrum-mainnet/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:06',
+    },
+    {
+      id: 'IR0D5BUY',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:06',
+    },
+    {
+      id: 'XMXILQVD',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/arbitrum-mainnet/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:06',
+    },
+    {
+      id: 'YDVH2XQG',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:06',
+    },
+    {
+      id: '7CTL9KHX',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:07',
+    },
+    {
+      id: 'R5KGDSJI',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:07',
+    },
+    {
+      id: '4KNR6ELM',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:08',
+    },
+    {
+      id: 'J4OBEPTE',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:08',
+    },
+    {
+      id: 'U8B0F4CT',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:08',
+    },
+    {
+      id: 'VZUNNBGV',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:08',
+    },
+    {
+      id: 'YSKIWPLS',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:08',
+    },
+    {
+      id: '0XWO4N4I',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:09',
+    },
+    {
+      id: 'DZPGG0I8',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:09',
+    },
+    {
+      id: 'H50FXZ73',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:09',
+    },
+    {
+      id: 'N1OF1UZ8',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:09',
+    },
+    {
+      id: 'WYSUWDSJ',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:09',
+    },
+    {
+      id: '5SLYILO3',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:10',
+    },
+    {
+      id: 'DHLPOXCT',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:10',
+    },
+    {
+      id: 'EHYGYJK3',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:10',
+    },
+    {
+      id: 'HU66ANFW',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:10',
+    },
+    {
+      id: 'JTXPZAMH',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:10',
+    },
+    {
+      id: 'QUNYNQKF',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:10',
+    },
+    {
+      id: 'BTFWR2F9',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:11',
+    },
+    {
+      id: 'CVT29IE3',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:11',
+    },
+    {
+      id: 'QS2I9DDE',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:11',
+    },
+    {
+      id: 'TYLPSBTO',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:11',
+    },
+    {
+      id: '5SABZ3YC',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:12',
+    },
+    {
+      id: 'C5MTQUOF',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:12',
+    },
+    {
+      id: 'CSG7MXZE',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/socket/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:12',
+    },
+    {
+      id: 'CXBYHXWO',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:12',
+    },
+    {
+      id: 'VNGTVWUX',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/socket/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:12',
+    },
+    {
+      id: '6ZFDGA8Z',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/socket/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:13',
+    },
+    {
+      id: 'OF3PEV9G',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/xdai/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:13',
+    },
+    {
+      id: 'TBQR17TC',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:13',
+    },
+    {
+      id: 'WBODOFAK',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:13',
+    },
+    {
+      id: 'XMCEG2CF',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/xdai/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:13',
+    },
+    {
+      id: '8DDVCELX',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:14',
+    },
+    {
+      id: 'SLYRXJZK',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:14',
+    },
+    {
+      id: 'USYVDOV2',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:14',
+    },
+    {
+      id: 'UVVP5PGY',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:14',
+    },
+    {
+      id: 'KZDWAOUW',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:15',
+    },
+    {
+      id: '9820I5UX',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:16',
+    },
+    {
+      id: 'LB4CN0TN',
+      object: 'event',
+      name: 'arbitrum-42161/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:16',
+    },
+    {
+      id: 'OGBTQGIZ',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:16',
+    },
+    {
+      id: 'UUFNKTOU',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/arbitrum-42161/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:16',
+    },
+    {
+      id: '3UFBEOQ7',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:17',
+    },
+    {
+      id: 'H3YPX7X8',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:17',
+    },
+    {
+      id: 'NEELN1FL',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:17',
+    },
+    {
+      id: 'PIHTIOXI',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:17',
+    },
+    {
+      id: 'UDK1B6GZ',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:17',
+    },
+    {
+      id: '1RC6EZNH',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:19',
+    },
+    {
+      id: '8SR80H3E',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:19',
+    },
+    {
+      id: 'U0AIKPQ8',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:19',
+    },
+    {
+      id: 'XC1A7DAL',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:19',
+    },
+    {
+      id: 'DFBJIADF',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:20',
+    },
+    {
+      id: 'GCT9ZTPJ',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:20',
+    },
+    {
+      id: 'JYHTF4P7',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:20',
+    },
+    {
+      id: 'MZYBFAXY',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/polygon-137/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:20',
+    },
+    {
+      id: 'PNBTOJWZ',
+      object: 'event',
+      name: 'polygon-137/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:20',
+    },
+    {
+      id: '6DWAXMIS',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/optimism-10/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:21',
+    },
+    {
+      id: 'MUH5FTS4',
+      object: 'event',
+      name: 'bsc-56/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:21',
+    },
+    {
+      id: 'PVY6UOF7',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:21',
+    },
+    {
+      id: 'U9UZ4EQH',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/connext/bsc-56/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:21',
+    },
+    {
+      id: 'YGLUCRGP',
+      object: 'event',
+      name: 'optimism-10/ecoBridge/connext/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:21',
+    },
+    {
+      id: '2GDIENPO',
+      object: 'event',
+      name: 'ethereum-1/ecoBridge/omnibridge-eth-xdai/gnosis-100/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:22',
+    },
+    {
+      id: 'R5JAXFNA',
+      object: 'event',
+      name: 'gnosis-100/ecoBridge/omnibridge-eth-xdai/ethereum-1/volumeUSD',
+      currency: null,
+      created_at: '2023-01-12 10:07:22',
+    },
   ],
-  timestamp: '2023-01-05T14:50:46.003Z',
+  timestamp: '2023-01-12T12:10:01.303Z',
 }
 
 /**
@@ -321,4 +865,18 @@ export function getNetworkNameByChainId(chainId: number): string {
  */
 export function getEcoRouterVolumeUSDEventName(networkName: string, networkId: number, platformName: string): string {
   return `${networkName.toLowerCase()}-${networkId}/ecoRouter/${platformName.toLowerCase()}/volumeUSD`
+}
+
+/**
+ * Constructs EcoBridge volumeUSD event name for a given platform, from network and to network
+ */
+export function getEcoBridgeVolumeUSDEventName(
+  platformName: string,
+  fromNetworkId: number,
+  toNetworkId: number
+): string {
+  const fromNetworkName = getNetworkNameByChainId(fromNetworkId)
+  const toNetworkName = getNetworkNameByChainId(toNetworkId)
+  platformName = platformName.replace(/:/g, '-').toLowerCase()
+  return `${fromNetworkName}-${fromNetworkId}/ecoBridge/${platformName}/${toNetworkName}-${toNetworkId}/volumeUSD`
 }

--- a/src/analytics/provider/analytics.context.ts
+++ b/src/analytics/provider/analytics.context.ts
@@ -2,6 +2,7 @@ import { Trade } from '@swapr/sdk'
 
 import { createContext } from 'react'
 
+import { BridgeTransactionSummary } from '../../state/bridgeTransactions/types'
 import { Fathom } from '../fathom'
 import { FathomSiteInformation } from '../generated/prod'
 
@@ -17,7 +18,11 @@ export interface IAnalyticsContext {
   /**
    * Track the volume of a trade in USD and send it to Fathom
    */
-  trackEcoEcoRouterTradeVolume(trade: Trade): void
+  trackEcoRouterTradeVolume(trade: Trade): void
+  /**
+   * Track the volume of a trade in USD and send it to Fathom
+   */
+  trackEcoBridgeTradeVolume(transactionSummary: BridgeTransactionSummary): void
 }
 
 export const AnalyticsContext = createContext({} as IAnalyticsContext)

--- a/src/analytics/provider/analytics.provider.tsx
+++ b/src/analytics/provider/analytics.provider.tsx
@@ -4,11 +4,12 @@ import debugFactory from 'debug'
 import { useEffect, useRef, useState } from 'react'
 
 import { useEnvironment } from '../../hooks/useEnvironment'
+import { BridgeTransactionSummary } from '../../state/bridgeTransactions/types'
 import { loadFathom } from '../fathom'
 import { siteEvents as siteEventsDev } from '../generated/dev'
 import { FathomSiteInformation, siteEvents as siteEventsProd } from '../generated/prod'
 import * as trackers from '../trackers'
-import { computeTradeId } from '../utils'
+import { computeItemId } from '../utils'
 import { AnalyticsContext, IAnalyticsContext } from './analytics.context'
 import { AnalyticsTradeQueueState, ItemStatus } from './analytics.state'
 
@@ -30,19 +31,17 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
   useEffect(() => {
     const siteId = process.env.REACT_APP_FATHOM_SITE_ID
     const siteScriptURL = process.env.REACT_APP_FATHOM_SITE_SCRIPT_URL
-    const siteEvents = isProduction ? siteEventsProd : siteEventsDev
+    const siteEvents = siteEventsProd.siteId === siteId ? siteEventsProd : siteEventsDev
 
-    debug('Loading Fathom', { siteId, siteScriptURL })
+    debug('Loading Fathom', { siteId, siteScriptURL, siteEvents })
 
-    if (!siteId) {
-      if (isDevelopment) {
-        console.warn('REACT_APP_FATHOM_SITE_ID not set, skipping Fathom analytics')
-      }
+    if (!siteId && isDevelopment) {
+      console.warn('REACT_APP_FATHOM_SITE_ID not set, skipping Fathom analytics')
       return
     }
 
     if (siteId !== siteEvents.siteId) {
-      console.error(`Fathom site ID (${siteId}) not found in generated fathom settings`)
+      console.error(`Fathom site ID (${siteId}) not found in generated fathom settings. Found (${siteEvents.siteId})`)
       return
     }
 
@@ -85,7 +84,11 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
       for await (const pendingItem of pendingItems) {
         debug('Processing item', { pendingItem })
         try {
-          await trackers.trackEcoEcoRouterTradeVolume(pendingItem.trade, site as FathomSiteInformation)
+          if (pendingItem.item instanceof Trade) {
+            await trackers.trackEcoRouterTradeVolume(pendingItem.item, site as FathomSiteInformation)
+          } else {
+            await trackers.trackEcoBridgeTradeVolume(pendingItem.item, site as FathomSiteInformation)
+          }
 
           const payload = {
             ...pendingItem,
@@ -125,25 +128,50 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
     }
   }, [site, tradeQueue])
 
-  const trackEcoEcoRouterTradeVolume = (trade: Trade) => {
+  const trackEcoRouterTradeVolume = (trade: Trade) => {
     if (!site || !window.fathom) {
-      console.error('trackEcoEcoRouterTradeVolume: Fathom site not found', { site, fathom: window.fathom })
-      return
+      return console.error('Fathom site not found', { site, fathom: window.fathom })
     }
 
     // Attempt to process the trade volume event
     // If it fails, add it to the queue
     trackers
-      .trackEcoEcoRouterTradeVolume(trade, site)
-      .then(() => {
-        debug('trackEcoEcoRouterTradeVolume: processed trade volume event', { trade })
-      })
+      .trackEcoRouterTradeVolume(trade, site)
+      .then(() => debug('processed trade volume event', { trade }))
       .catch(error => {
-        console.error('trackEcoEcoRouterTradeVolume: Error processing trade', { trade, error })
-        const id = computeTradeId(trade)
+        console.error('Error processing trade', { trade, error })
+        const id = computeItemId(trade)
         setTradeQueue(state => ({
           ...state,
-          [id]: { id: computeTradeId(trade), trade, status: ItemStatus.PENDING, retries: 0 },
+          [id]: {
+            id,
+            item: trade,
+            status: ItemStatus.PENDING,
+            retries: 0,
+          },
+        }))
+      })
+  }
+
+  const trackEcoBridgeTradeVolume = (transactionSummary: BridgeTransactionSummary) => {
+    if (!site || !window.fathom) {
+      return console.error('Fathom site not found', { site, fathom: window.fathom })
+    }
+
+    trackers
+      .trackEcoBridgeTradeVolume(transactionSummary, site)
+      .then(() => debug('processed trade volume event', { transactionSummary }))
+      .catch(error => {
+        console.error('Error processing trade', { transactionSummary, error })
+        const id = computeItemId(transactionSummary)
+        setTradeQueue(state => ({
+          ...state,
+          [id]: {
+            id,
+            item: transactionSummary,
+            status: ItemStatus.PENDING,
+            retries: 0,
+          },
         }))
       })
   }
@@ -154,7 +182,8 @@ export function AnalyticsProvider({ children }: AnalyticsProviderProps) {
         {
           site,
           fathom: window.fathom,
-          trackEcoEcoRouterTradeVolume,
+          trackEcoRouterTradeVolume,
+          trackEcoBridgeTradeVolume,
         } as IAnalyticsContext
       }
     >

--- a/src/analytics/provider/analytics.state.ts
+++ b/src/analytics/provider/analytics.state.ts
@@ -1,5 +1,7 @@
 import { Trade } from '@swapr/sdk'
 
+import { BridgeTransactionSummary } from '../../state/bridgeTransactions/types'
+
 export enum ActionType {
   ADD = 'ADD',
   UPDATE = 'UPDATE',
@@ -14,7 +16,7 @@ export enum ItemStatus {
 
 interface AnalyticsTradeQueueItem {
   id: string
-  trade: Trade
+  item: Trade | BridgeTransactionSummary
   status: ItemStatus
   retries: number
 }

--- a/src/analytics/trackers/index.ts
+++ b/src/analytics/trackers/index.ts
@@ -1,9 +1,16 @@
+import { AddressZero } from '@ethersproject/constants'
 import { Trade } from '@swapr/sdk'
 
 import debugFactory from 'debug'
 
-import { getTradeUSDValue } from '../../utils/coingecko'
-import { FathomSiteInformation, getEcoRouterVolumeUSDEventName, getNetworkNameByChainId } from '../generated/prod'
+import { BridgeTransactionSummary } from '../../state/bridgeTransactions/types'
+import { getTradeUSDValue, getUSDPriceCurrencyQuote, getUSDPriceTokenQuote } from '../../utils/coingecko'
+import {
+  FathomSiteInformation,
+  getEcoBridgeVolumeUSDEventName,
+  getEcoRouterVolumeUSDEventName,
+  getNetworkNameByChainId,
+} from '../generated/prod'
 
 const debug = debugFactory('analytics:trackers')
 
@@ -13,8 +20,8 @@ const debug = debugFactory('analytics:trackers')
  * @returns void
  * @throws Error on null USD value and when
  */
-export async function trackEcoEcoRouterTradeVolume(trade: Trade, site: FathomSiteInformation) {
-  debug('tracking trade USD volume', { trade, site })
+export async function trackEcoRouterTradeVolume(trade: Trade, site: FathomSiteInformation) {
+  debug('tracking EcoRouter trade USD volume', { trade, site })
   // Get use value for input amount
   const tradeUSDValue = await getTradeUSDValue(trade)
 
@@ -30,7 +37,44 @@ export async function trackEcoEcoRouterTradeVolume(trade: Trade, site: FathomSit
   const eventId = site.events.find(event => event.name === eventName)?.id
 
   if (!eventId) {
-    throw new Error(`Event ID for (${eventName}) not found`)
+    throw new Error(`Event ID for (${eventName}) not found in site (${site.siteId})`)
+  }
+
+  window.fathom.trackGoal(eventId, tradeUSDValueInCents)
+}
+
+/**
+ * Processes the trade volume event
+ * @param trade Trade
+ * @returns void
+ * @throws Error on null USD value and when
+ */
+export async function trackEcoBridgeTradeVolume(trade: BridgeTransactionSummary, site: FathomSiteInformation) {
+  debug('tracking EcoBridge trade USD volume', { trade, site })
+
+  const isNativeToken = (trade.assetAddressL1 === AddressZero || trade.assetAddressL1 === 'XDAI') && trade.fromChainId
+
+  let rawTokenPriceInfo = isNativeToken
+    ? await getUSDPriceCurrencyQuote({
+        chainId: trade.fromChainId,
+      })
+    : await getUSDPriceTokenQuote({
+        tokenAddress: trade.assetAddressL1,
+        chainId: trade.fromChainId,
+      })
+
+  if (rawTokenPriceInfo === null) {
+    throw new Error('Could not get token price')
+  }
+
+  const tokenUSDPrice = Object.values(rawTokenPriceInfo)[0].usd
+  const usdValue = (tokenUSDPrice * parseFloat(trade.fromValue)).toFixed(2)
+  const tradeUSDValueInCents = (parseFloat(parseFloat(usdValue).toFixed(2)) * 100).toString() // convert to cents because fathom requires it
+  const eventName = getEcoBridgeVolumeUSDEventName(trade.bridgeId, trade.fromChainId, trade.toChainId)
+  const eventId = site.events.find(event => event.name === eventName)?.id
+
+  if (!eventId) {
+    throw new Error(`Event ID for (${eventName}) not found in site (${site.siteId})`)
   }
 
   window.fathom.trackGoal(eventId, tradeUSDValueInCents)

--- a/src/analytics/utils/index.ts
+++ b/src/analytics/utils/index.ts
@@ -1,12 +1,21 @@
 import { Trade } from '@swapr/sdk'
 
+import { BridgeTransactionSummary } from '../../state/bridgeTransactions/types'
+
 /**
- * Creates an unique ID for a trade instance
- * @param trade
+ * Creates an unique ID for a trade and bridge transaction instance.
+ * @param item
  * @returns
  */
-export function computeTradeId(trade: Trade) {
-  return `${trade.platform.name.toLowerCase()}-${trade.chainId}/${trade.inputAmount.currency.address}-${
-    trade.outputAmount.currency.address
-  }-${trade.inputAmount.raw.toString()}-${trade.outputAmount.raw.toString()}`
+export function computeItemId(item: Trade | BridgeTransactionSummary) {
+  if (item instanceof Trade) {
+    return `${item.platform.name.toLowerCase()}-${item.chainId}/${item.inputAmount.currency.address}-${
+      item.outputAmount.currency.address
+    }-${item.inputAmount.raw.toString()}-${item.outputAmount.raw.toString()}`
+  }
+
+  // the ID is not meant to be readable, it's just a unique identifier
+  return `ecoBridge/${item.bridgeId.toLowerCase()}/${item.fromChainId}:${item.toChainId}/${item.fromValue}:${
+    item.toValue
+  }`
 }

--- a/src/hooks/useSwapCallback.ts
+++ b/src/hooks/useSwapCallback.ts
@@ -164,7 +164,7 @@ export function useSwapCallback({
   const mainnetGasPrices = useMainnetGasPrices()
   const [preferredGasPrice] = useUserPreferredGasPrice()
 
-  const { trackEcoEcoRouterTradeVolume } = useAnalytics()
+  const { trackEcoRouterTradeVolume } = useAnalytics()
 
   const memoizedTrades = useMemo(() => (trade ? [trade] : undefined), [trade])
 
@@ -198,7 +198,7 @@ export function useSwapCallback({
           await trade.signOrder(signer, recipient)
           const orderId = await trade.submitOrder()
 
-          trackEcoEcoRouterTradeVolume(trade)
+          trackEcoRouterTradeVolume(trade)
 
           addTransaction(
             {
@@ -295,7 +295,7 @@ export function useSwapCallback({
             ...((await transactionParameters) as any),
           })
           .then(async response => {
-            trackEcoEcoRouterTradeVolume(trade)
+            trackEcoRouterTradeVolume(trade)
             addTransaction(response, {
               summary: getSwapSummary(trade, recipient),
             })
@@ -326,6 +326,6 @@ export function useSwapCallback({
     recipientAddressOrName,
     recipient,
     addTransaction,
-    trackEcoEcoRouterTradeVolume,
+    trackEcoRouterTradeVolume,
   ])
 }


### PR DESCRIPTION
# Summary

Adds tracking ability to EcoBridge transactions. I think the implementation is a bit hacky; please look at the Transaction Summary component to see the logic. 

The convention for tracking USD volume is as follows:

`<FromChain>/ecoBridge/<BridgeName>/<ToChain>/usdVolume`

Examples:

 - `ethereum-1/ecoBridge/socket/arbitrum-42161/volumeUSD`
 - `arbitrum-42161/ecoBridge/socket/ethereum-1/volumeUSD`
 - `arbitrum-42161/ecoBridge/socket/polygon-137/volumeUSD`
 - `polygon-137/ecoBridge/socket/arbitrum-42161/volumeUSD`

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/1926216/212203549-ebfde46d-0b52-4111-a701-faba0a7439d9.png">

[Bridge tx](https://gnosisscan.io/tx/0x73367f4c65e467801eecccb48ed5949b875c99eacae3527862e41cf512d5ce82)
