### PR TITLE
chore: add page views for pro swap

### DIFF
--- a/src/analytics/fathom/fathom.types.ts
+++ b/src/analytics/fathom/fathom.types.ts
@@ -5,6 +5,7 @@ export interface Fathom {
   setSite(siteId: string): void
   trackGoal(goalId: string, data: any): void
   trackEvent(eventId: string, payload: Record<string, any>): void
+  trackPageview(params?: Record<string, any>): void
 }
 
 declare global {

--- a/src/pages/Swap/Components/ChartTabs.tsx
+++ b/src/pages/Swap/Components/ChartTabs.tsx
@@ -40,6 +40,7 @@ export const ChartTabs = ({
             if (activeChartTab !== ChartOptions.PRO) {
               setActiveChartTab(ChartOptions.PRO)
               navigate('/swap/pro')
+              window.fathom.trackPageview()
             }
           }}
           title={
@@ -56,6 +57,7 @@ export const ChartTabs = ({
           onClick={() => {
             setActiveChartTab(ChartOptions.OFF)
             navigate('/swap')
+            window.fathom.trackPageview()
           }}
           title={t('advancedTradingView.chartTabs.offTitle')}
           disabled={!isDesktop}


### PR DESCRIPTION
# Summary

Adds necessary hooks to send page view when users hops between simple and advanced trading view