### PR TITLE
fix: add liquidity bug

### DIFF
--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -68,7 +68,7 @@ export function usePairs(
       const { reserve0, reserve1 } = reserves
       const [token0, token1] = tokenA.sortsBefore(tokenB) ? [tokenA, tokenB] : [tokenB, tokenA]
       const swapFee = swapFees?.[Pair.getAddress(token0, token1, platform)]?.fee
-      if (!swapFee && platform === UniswapV2RoutablePlatform.SWAPR) return [PairState.LOADING, null]
+
       return [
         PairState.EXISTS,
         new Pair(

--- a/src/state/mint/reducer.ts
+++ b/src/state/mint/reducer.ts
@@ -31,9 +31,7 @@ export default createReducer<MintState>(initialState, builder =>
         else {
           return {
             ...state,
-            independentField: field,
-            typedValue,
-            otherTypedValue: state.typedValue,
+            otherTypedValue: typedValue,
           }
         }
       } else {


### PR DESCRIPTION
# Summary

Fixes #1685

This PR fixes the add liquidity bug for new tokens

  # To Test

1. Go to create liquidity page
2. Choose token pair with no liquidity
- [ ] Can submit a value for Token A and Token B


