### PR TITLE
[#1693] Fix limit order SDK changes

### DIFF
--- a/src/pages/Swap/LimitOrderBox/components/ConfirmLimitOrderModal/ConfirmationHeader.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/ConfirmLimitOrderModal/ConfirmationHeader.tsx
@@ -4,6 +4,7 @@ import { ArrowDown } from 'react-feather'
 import styled from 'styled-components'
 
 import { CurrencyLogo } from '../../../../../components/CurrencyLogo'
+import { toFixedSix } from '../LimitOrderForm/utils'
 
 export type HeaderData = {
   fiatValueInput: CurrencyAmount | null
@@ -27,7 +28,7 @@ export const ConfirmationHeader = ({ fiatValueInput, fiatValueOutput, buyToken, 
           </LogoWithText>
         </CurrencyLogoInfo>
         <AmountWithUsd>
-          <Amount>{sellToken.toExact()}</Amount>
+          <Amount>{toFixedSix(Number(sellToken.toExact()))}</Amount>
           {fiatInput && <PurpleText>${fiatInput}</PurpleText>}
         </AmountWithUsd>
       </CurrencyAmountContainer>
@@ -41,7 +42,7 @@ export const ConfirmationHeader = ({ fiatValueInput, fiatValueOutput, buyToken, 
           </LogoWithText>
         </CurrencyLogoInfo>
         <AmountWithUsd>
-          <Amount>{buyToken.toExact()}</Amount>
+          <Amount>{toFixedSix(Number(buyToken.toExact()))}</Amount>
           {fiatOutput && <PurpleText>${fiatOutput}</PurpleText>}
         </AmountWithUsd>
       </CurrencyAmountContainer>
@@ -87,8 +88,8 @@ const AmountWithUsd = styled.div`
 `
 const Amount = styled.div`
   font-weight: 600;
-  font-size: 28px;
-  line-height: 34px;
+  font-size: 20px;
+  line-height: 28px;
 `
 const PurpleText = styled.div`
   font-weight: 600;

--- a/src/pages/Swap/LimitOrderBox/components/ConfirmLimitOrderModal/index.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/ConfirmLimitOrderModal/index.tsx
@@ -12,23 +12,25 @@ import { calculateMarketPriceDiffPercentage } from '../../utils'
 import { ConfirmationFooter } from './ConfirmationFooter'
 import { ConfirmationHeader } from './ConfirmationHeader'
 
-export default function ConfirmLimitOrderModal({
-  onConfirm,
-  onDismiss,
-  errorMessage,
-  isOpen,
-  attemptingTxn,
-  fiatValueInput,
-  fiatValueOutput,
-}: {
+interface ConfirmLimitOrderModalProps {
   isOpen: boolean
   attemptingTxn: boolean
-  onConfirm: () => void
   errorMessage: string | undefined
-  onDismiss: () => void
   fiatValueInput: CurrencyAmount | null
   fiatValueOutput: CurrencyAmount | null
-}) {
+  onDismiss: () => void
+  onConfirm: () => void
+}
+
+export default function ConfirmLimitOrderModal({
+  isOpen,
+  attemptingTxn,
+  errorMessage,
+  fiatValueInput,
+  fiatValueOutput,
+  onDismiss,
+  onConfirm,
+}: ConfirmLimitOrderModalProps) {
   const { expiresIn, expiresInUnit, limitOrder, buyTokenAmount, sellTokenAmount, formattedLimitPrice, marketPrices } =
     useContext(LimitOrderFormContext)
 

--- a/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
@@ -202,8 +202,8 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
 
       setMarketPriceInterval(refetchMarketPrice)
     } else {
-      clearInterval(marketPriceInterval)
       setMarketPriceInterval(undefined)
+      clearInterval(marketPriceInterval)
     }
 
     return () => {

--- a/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
+++ b/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/LimitOrderForm.tsx
@@ -53,7 +53,7 @@ export interface LimitOrderFormProps {
  * The Limit Order Form is the base component for all limit order forms.
  */
 export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormProps) {
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const notify = useNotificationPopup()
   // Get the initial values and set the state
   let initialState = useRef(getInitialState(chainId, account)).current
@@ -218,6 +218,11 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
     buyTokenAmount?.currency,
   ])
 
+  const isLoading = () => {
+    setLoading(true)
+    setIsPossibleToOrder({ status: true, value: 0 })
+  }
+
   // Fetch the maximum amount of tokens that can be bought or sold
   const sellCurrencyMaxAmount = maxAmountSpend(sellCurrencyBalance, chainId)
   const buyCurrencyMaxAmount = maxAmountSpend(buyCurrencyBalance, chainId, false)
@@ -240,11 +245,11 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
   const showApproveFlow = tokenInApproval === ApprovalState.NOT_APPROVED || tokenInApproval === ApprovalState.PENDING
 
   const handleSwapTokens = useCallback(() => {
+    isLoading()
     setSellTokenAmount(buyTokenAmount)
     setBuyTokenAmount(sellTokenAmount)
     setFormattedSellAmount(formattedBuyAmount)
     setFormattedBuyAmount(formattedSellAmount)
-    setIsPossibleToOrder({ status: false, value: 0 })
     if (buyTokenAmount.currency.address && sellTokenAmount.currency.address) {
       setLimitOrder(limitOrder => ({
         ...limitOrder,
@@ -298,7 +303,7 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
   const newSellAmount = previousSellAmount?.raw.toString() !== sellCurrencyBalance?.raw.toString()
 
   useEffect(() => {
-    const timeoutId = setTimeout(() => {
+    const timeoutId = setTimeout(async () => {
       const amountWei = parseUnits(
         parseFloat(formattedSellAmount).toFixed(6),
         sellTokenAmount?.currency?.decimals
@@ -306,7 +311,7 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
       const expiresAt = dayjs().add(GET_QUOTE_EXPIRY_MINUTES, OrderExpiresInUnit.Minutes).unix()
       const sellCurrencyMaxAmount = maxAmountSpend(sellCurrencyBalance, chainId)
 
-      checkMaxOrderAmount(
+      await checkMaxOrderAmount(
         limitOrder,
         setIsPossibleToOrder,
         setLimitOrder,
@@ -317,6 +322,7 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
         chainId,
         provider
       )
+      setLoading(false)
     }, 500)
     return () => clearTimeout(timeoutId)
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -411,6 +417,7 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
 
   const handleInputOnChange =
     (token: Token, inputFocus: InputFocus, handleAmountChange: Function) => (formattedValue: string) => {
+      isLoading()
       const amountFormatted = formattedValue.trim() === '' ? '0' : formattedValue
       const amountWei = parseUnits(formattedValue, token.decimals).toString()
       handleAmountChange({
@@ -424,6 +431,7 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
   const handleCurrencySelect =
     (prevTokenAmount: TokenAmount, handleCurrencyAmountChange: Function, amountFormatted: string) =>
     (currency: Currency) => {
+      isLoading()
       let amountWei
       if (amountFormatted) amountWei = parseUnits(amountFormatted, currency?.decimals).toString()
       else if (prevTokenAmount?.raw) {
@@ -596,11 +604,11 @@ export function LimitOrderForm({ account, provider, chainId }: LimitOrderFormPro
               <>
                 {isPossibleToOrder.status && isPossibleToOrder.value > 0 && (
                   <MaxAlert>
-                    Max possible amount with fees for {sellTokenAmount.currency.symbol} is{' '}
+                    Max possible amount for {sellTokenAmount.currency.symbol} is{' '}
                     {formatMaxValue(isPossibleToOrder.value)}
                   </MaxAlert>
                 )}
-                <ButtonPrimary onClick={() => setIsModalOpen(true)} disabled={isPossibleToOrder.status}>
+                <ButtonPrimary onClick={() => setIsModalOpen(true)} disabled={isPossibleToOrder.status || loading}>
                   Place Limit Order
                 </ButtonPrimary>
               </>

--- a/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/utils.ts
+++ b/src/pages/Swap/LimitOrderBox/components/LimitOrderForm/utils.ts
@@ -38,20 +38,17 @@ export const checkMaxOrderAmount = async (
     return
   }
 
-  const { sellAmount, feeAmount } = quote
-  const sellAmountFormatted = Number(formatUnits(sellAmount, sellTokenAmount.currency.decimals) ?? 0)
-  const feeAmountFormatted = Number(formatUnits(feeAmount, sellTokenAmount.currency.decimals) ?? 0)
-  const maxAmount = Number(formatUnits(sellCurrencyMaxAmount.raw.toString(), sellTokenAmount.currency.decimals) ?? 0)
+  const { sellAmount } = quote
+  const totalSellAmount = Number(formatUnits(sellAmount, sellTokenAmount.currency.decimals) ?? 0)
+  const maxAmountAvailable = Number(
+    formatUnits(sellCurrencyMaxAmount.raw.toString(), sellTokenAmount.currency.decimals) ?? 0
+  )
   // Since fee amount is recalculated again before order
-  // for safe side checking 2x of current feeAmount returned by quote
-  const totalSellAmount = sellAmountFormatted + feeAmountFormatted * 2
-  setLimitOrder(oldLimitOrder => ({ ...oldLimitOrder, feeAmount: Number(feeAmount).toString() }))
-  if (totalSellAmount > maxAmount) {
-    const maxSellAmountPossibleWithFee = maxAmount - feeAmountFormatted * 2 < 0 ? 0 : maxAmount - feeAmountFormatted * 2
-
+  if (totalSellAmount > maxAmountAvailable) {
+    const maxSellAmountPossible = maxAmountAvailable < 0 ? 0 : maxAmountAvailable
     setIsPossibleToOrder({
       status: true,
-      value: maxSellAmountPossibleWithFee,
+      value: maxSellAmountPossible,
     })
   } else {
     setIsPossibleToOrder({

--- a/src/pages/Swap/LimitOrderBox/components/OrderLimitPriceField/styles.ts
+++ b/src/pages/Swap/LimitOrderBox/components/OrderLimitPriceField/styles.ts
@@ -10,11 +10,11 @@ export const LimitLabel = styled(InputGroup.Label)`
 `
 
 export const SetToMarket = styled.button`
-  font-size: 11px;
+  font-size: 10px;
   color: #8c83c0;
   border: none;
   cursor: pointer;
-  background-color: #686e9410;
+  background-color: #2a2f41;
   border-radius: 5px;
   text-transform: uppercase;
   padding: 3px 8px;

--- a/src/pages/Swap/LimitOrderBox/utils/hooks.ts
+++ b/src/pages/Swap/LimitOrderBox/utils/hooks.ts
@@ -79,7 +79,7 @@ function cancelOpenOrder(status: OrderMetaData['status'], chainId: ChainId, upda
       const signer = provider.getSigner()
       // Cancel an open order
       const response = await deleteOpenOrders(chainId, uid, signer)
-      if (response === 'Cancelled') {
+      if (response === 'cancelled') {
         // Refetch orders
         await updateLimitOrderTransactions()
         return true


### PR DESCRIPTION
# Summary

#1693 

<img width="537" alt="Screenshot 2023-01-22 at 16 40 20" src="https://user-images.githubusercontent.com/102727631/213924837-3eef2cbd-c256-4768-914a-bb5aec0b39c8.png">

Now limit order `Maximum possible amount ` is showing after reducing the fees. Since the new CoW SDK change we don't want to pass the fees. 
So its a better experience for the users.
API for Cancel an open order has changed in the new SDK and need to make those changes to work.

  # To Test

- Should be able to place a limit order with the maximum available amount
- Should be able to cancel and open limit order.

