### PR TITLE
Fix yarn install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
           java-version: '17'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --cache-folder $(yarn cache dir)
+        run: yarn install --immutable
 
       - name: Generate open-api
         run: yarn codegen:socket
@@ -382,7 +382,7 @@ jobs:
           java-version: '17'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --cache-folder $(yarn cache dir)
+        run: yarn install --immutable
 
       - name: Generate open-api
         run: yarn codegen:socket
@@ -394,7 +394,7 @@ jobs:
         run: yarn codegen:graphql
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile --cache-folder $(yarn cache dir)
+        run: yarn install --immutable
 
       - name: Verify Cypress
         run: yarn cypress install


### PR DESCRIPTION
# Summary

The last yarn upgrade missed fixing CI yarn install for synpress and cypress. So it's failing.

In develop branch CI is failing in yarn install.

  # To Test

Created another bug to fix the Cypress failing and fix the multiple yarn install steps. #1708 


