### PR TITLE
fix: limit order unsupported chains bug

### DIFF
--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -300,7 +300,7 @@ export default function Bridge() {
         activeChainId: account ? chainId : -1,
         showTestnets: isDevelopment,
       }),
-    [account, chainId, collectableTx, isCollecting, fromChainId, onFromNetworkChange]
+    [onFromNetworkChange, isCollecting, collectableTx, fromChainId, account, chainId, isDevelopment]
   )
 
   const toNetworkList = useMemo(
@@ -313,7 +313,7 @@ export default function Bridge() {
         activeChainId: account ? chainId : -1,
         showTestnets: isDevelopment,
       }),
-    [account, chainId, collectableTx, isCollecting, onToNetworkChange, toChainId]
+    [account, chainId, collectableTx, isCollecting, isDevelopment, onToNetworkChange, toChainId]
   )
 
   return (

--- a/src/pages/Swap/LimitOrderBox/contexts/LimitOrderFormProvider.tsx
+++ b/src/pages/Swap/LimitOrderBox/contexts/LimitOrderFormProvider.tsx
@@ -11,6 +11,7 @@ import { useHigherUSDValue } from '../../../../hooks/useUSDValue'
 import { useDefaultsFromURLSearch } from '../../../../state/swap/hooks'
 import { Field } from '../../../../state/swap/types'
 import { SwapContext } from '../../SwapBox/SwapContext'
+import { supportedChainIdList } from '../constants/index'
 import { InputFocus, OrderExpiresInUnit } from '../interfaces'
 import { getInitialState } from '../utils'
 import { LimitOrderFormContext } from './LimitOrderFormContext'
@@ -121,8 +122,9 @@ export function LimitOrderFormBaseConditionalProvider({
 
 export const LimitOrderFromProvider = ({ children }: { children: ReactNode }) => {
   const { chainId, account } = useActiveWeb3React()
+  const noLimitOrderSupport = chainId ? !supportedChainIdList.includes(chainId) : true
 
-  if (!chainId || !account) return <>{children}</>
+  if (!chainId || noLimitOrderSupport || !account) return <>{children}</>
 
   return (
     <LimitOrderFormBaseConditionalProvider chainId={chainId} account={account}>


### PR DESCRIPTION
# Summary

This PR fixes a bug where the limit order provider doesn't work well outside unsupported chains

  # To Test

1. Open application in any page while in testnet
- [ ] Verify you can navigate to bridge and swap

