### PR TITLE
fix: show 1inch platform

### DIFF
--- a/src/lib/eco-router/platforms.ts
+++ b/src/lib/eco-router/platforms.ts
@@ -26,6 +26,7 @@ export function getSupportedPlatformsByChainId(chainId: ChainId) {
     RoutablePlatform.ZEROX,
     RoutablePlatform.UNISWAP,
     RoutablePlatform.COW,
+    RoutablePlatform.ONE_INCH,
     UniswapV2RoutablePlatform.SWAPR,
     UniswapV2RoutablePlatform.SUSHISWAP,
     UniswapV2RoutablePlatform.HONEYSWAP,


### PR DESCRIPTION
# Summary

Show 1inch platform

  # To Test

1. Simulate a trade
- [ ] 1inch platform appears in swapbox options

