### PR TITLE
fix: show dexscreener footer

### DIFF
--- a/src/pages/Swap/AdvancedTradingViewBox/AdvancedSwapMode/Chart/Chart.styles.tsx
+++ b/src/pages/Swap/AdvancedTradingViewBox/AdvancedSwapMode/Chart/Chart.styles.tsx
@@ -19,7 +19,7 @@ export const AbsoluteWrapper = styled.div`
 export const DexScreenerIframe = styled.div`
   position: relative;
   width: 100%;
-  height: 106.5%;
+  height: 100%;
   user-select: none;
 
   iframe {


### PR DESCRIPTION
# Summary

Fixes #1733

Show dexscreener footer on Pro chart

  # To Test

1. Open pro mode swap page
- [ ] Verify that chart has a dexscreener footer

