### PR TITLE
fix: unchecked number field when fetching blocks number

### DIFF
--- a/src/hooks/usePairVolume24hUSD.ts
+++ b/src/hooks/usePairVolume24hUSD.ts
@@ -63,7 +63,7 @@ function useBlockByTimestamp(timestamp: string) {
 
   return useMemo(() => {
     if (loading) return { loading: true, block: 0 }
-    if (!data || error) return { loading: false, block: 0, error: error }
+    if (!data?.blocks || data.blocks.length === 0 || error) return { loading: false, block: 0, error: error }
     return {
       loading,
       block: parseInt(data.blocks[0].number, 10),


### PR DESCRIPTION
## Fixes: #1751

# Description

This PR fixes a bug that appears when block by timestamp query is out of sync, by checking if any data is returned.

# How to test the changes

- Go to liquidity page on arbitrum